### PR TITLE
doplneni nedokumentovanych endpointu do API docs

### DIFF
--- a/docs/api_doc.md
+++ b/docs/api_doc.md
@@ -48,6 +48,12 @@ Podporuje:
 - Příklad:  
   - [https://quest.ms.mff.cuni.cz/edupo-api/input?text=Kdo%20si%20tady%20hraje%0aten%20si%20tady%20hraje\&accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/input?text=Kdo%20si%20tady%20hraje%0aten%20si%20tady%20hraje&accept=txt)   
 
+### Úplná specifikace parametrů pro generování
+`/get_generation_parameters_specification`
+- Vrací: JSON schéma třídy `GenerationParameters` (viz [`backend/data_types.py`](https://github.com/ufal/edupo/blob/main/backend/data_types.py)) popisující všechny parametry generování a jejich typy/výchozí hodnoty.
+- Příklad:
+  - [https://quest.ms.mff.cuni.cz/edupo-api/get_generation_parameters_specification?accept=json](https://quest.ms.mff.cuni.cz/edupo-api/get_generation_parameters_specification?accept=json)
+
 ### Generování básně
 `/gen`
 - Parametry (nepovinné, náhodné hodnoty pokud nejsou zadány):
@@ -74,6 +80,28 @@ Podporuje:
 - Příklad:  
   - [https://quest.ms.mff.cuni.cz/edupo-api/gen?metre=D\&rhyme\_scheme=ABBA\&syllables\_count=9\&accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/gen?metre=D&rhyme_scheme=ABBA&syllables_count=9&accept=txt)   
 
+### Interaktivní generování básně
+`/geninter`
+- Generuje báseň po částech (verších/skupinách veršů) s možností postupného doplňování ze strany uživatele.
+- Parametry:
+  - `interactive_mode` = režim interakce (výchozí `lines_gh`)
+  - `modelspec` = identifikátor modelu (výchozí `mc`)
+  - `title` = název básně (výchozí `Bez názvu`)
+  - `metre` = `T` / `J` / `D` / `N` (výchozí `T`)
+  - `rhyme_scheme` = např. `AABB` (výchozí `AABB`)
+  - `syllables_count` = počet slabik na řádek (výchozí `8`)
+  - `poemid` = ID rozpracované básně (volitelné, pro pokračování)
+  - `rawtext` = dosud vygenerovaný „surový“ text (pro pokračování)
+  - `userinput` = vstup uživatele (verš/část přidaná uživatelem)
+- Vrací: další část generované básně (a její `poemid`).
+
+### Přegenerování (oprava) jednoho verše
+`/regen`
+- Parametry:
+  - `poemid` = ID básně, kterou chceme upravit (povinné)
+  - `badline` = přesné znění verše, který má být nahrazen (povinné)
+- Vrací: novou verzi básně (s novým `poemid`), v níž je `badline` nahrazen verzí navrženou modelem (OpenAI). Nový verš se snaží zachovat rým a metrum původního verše.
+
 ### Vyhledání básně v korpusu
 `/search`
 - Parametry:
@@ -89,12 +117,25 @@ Podporuje:
 - Příklad:  
   - [https://quest.ms.mff.cuni.cz/edupo-api/showlist?accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/showlist?accept=txt)   
 
+`/showlistgen`
+- Vrací: seznam ID vygenerovaných básní (uložených jako JSON ve `static/poemfiles`), seřazený sestupně.
+- Příklad:
+  - [https://quest.ms.mff.cuni.cz/edupo-api/showlistgen?accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/showlistgen?accept=txt)
+
 `/showauthor`
 - Parametry:
   - `author` = Jméno autora (tak jak je ve výstupu `showlist`)
 - Vrací: Seznam sbírek a básní autora.
 - Příklad:  
     - [https://quest.ms.mff.cuni.cz/edupo-api/showauthor?author=Bezru%C4%8D,%20Petr\&accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/showauthor?author=Bezru%C4%8D,%20Petr&accept=txt) 
+
+### Typologické rysy autora
+`/typfeatures`
+- Parametry:
+  - `author` = jméno autora (pokud není zadáno, použije se výchozí seznam autorů: Mácha, Erben, Neruda, Hálek, Březina, Karásek ze Lvovic, Hlaváček, Gellner, Bezruč)
+- Vrací: textový přehled typologických rysů autora/autorů (počty básní a sbírek, top metra, top rýmová schémata, top motivy, typická slova podle TF-IDF). Aktuálně vrací jen plain text.
+- Příklad:
+  - [https://quest.ms.mff.cuni.cz/edupo-api/typfeatures?author=Bezru%C4%8D,%20Petr](https://quest.ms.mff.cuni.cz/edupo-api/typfeatures?author=Bezru%C4%8D,%20Petr)
 
 ### Zobrazení básně
 `/show`
@@ -113,6 +154,14 @@ Podporuje:
 - Příklad:  
   - [https://quest.ms.mff.cuni.cz/edupo-api/genmotives?poemid=72197\&accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/genmotives?poemid=72197&accept=txt)   
 
+### Odhad nálady básně
+`/guessmood`
+- Parametry:
+  - `poemid` = ID básně (povinné)
+  - `regenerate` = pokud je nastaveno (nenulové), vynutí nový odhad i pokud je již uložen
+- Vrací: jedno ze slov `veselá` / `smutná` / `žádná` (odhad převládající nálady básně).
+- Výsledek se cachuje do `static/mood/{poemid}.txt`.
+
 ### Generování ilustrace k básni
 `/genimage`
 - Parametry:
@@ -128,6 +177,28 @@ Podporuje:
 - Vrací: URL MP3 souboru s přednesem básně (relativní vůči serveru).
 - Příklad:  
   - [https://quest.ms.mff.cuni.cz/edupo-api/gentts?poemid=72197\&accept=txt](https://quest.ms.mff.cuni.cz/edupo-api/gentts?poemid=72197&accept=txt)   
+
+### Překlad básně
+`/translate`
+- Parametry:
+  - `poemid` = ID básně (povinné)
+  - `language` = cílový jazyk (výchozí `sk`). Pro `sk` se používá služba Česílko (CS→SK), pro ostatní jazyky překladač LINDAT (`cs-<language>`, např. `uk`).
+- Vrací: text přeloženého textu básně. Překlad se uloží do dat básně pod klíčem `translations[language]`.
+
+### Analytické zpracování básně modelem LLM
+`/processopenai`
+- Aplikuje libovolný uživatelský prompt na zadanou báseň pomocí LLM (OpenAI / OpenRouter).
+- Parametry:
+  - `poemid` = ID básně (povinné)
+  - `openaiprompt` = systémový/instrukční prompt aplikovaný na text básně (povinné)
+  - `modelspec` = identifikátor modelu (výchozí `gpt-4o-mini`)
+- Vrací: výstup modelu. Záznamy `{model, prompt, output}` se kumulují v poli `openai` v datech básně.
+
+### Volné generování textu modelem LLM
+`/openaigenerate`
+- Parametry:
+  - `prompt` = prompt pro model (výchozí `Máte rádi ptakopysky?`)
+- Vrací: HTML stránku s výstupem modelu (jednoduché rozhraní, vrací vždy HTML).
 
 ### Lajkování
 `/like_count`


### PR DESCRIPTION
Pridava do docs/api_doc.md endpointy /geninter, /regen, /showlistgen, /typfeatures, /guessmood, /translate, /processopenai, /openaigenerate a /get_generation_parameters_specification.